### PR TITLE
30_受講生情報更新処理の実装

### DIFF
--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -16,7 +16,7 @@ public class Student {
   private int age;
   private String gender;
   private String remark;
-  private boolean isDeleted; // 'is_deleted'
+  private boolean deleted;
 }
 
 

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -10,8 +10,7 @@ import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 
 /**
- * 受講生情報を扱うリポジトリ。
- *全件検索や単位等条件での検索、コース情報の検索が行えるクラス。
+ * 受講生情報を扱うリポジトリ。 全件検索や単位等条件での検索、コース情報の検索が行えるクラス。
  */
 @Mapper
 public interface StudentRepository {
@@ -21,7 +20,7 @@ public interface StudentRepository {
    *
    * @return 受講生情報の一覧
    */
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE deleted='false'")
   List<Student> searchStudent();
 
   /**
@@ -32,7 +31,7 @@ public interface StudentRepository {
   @Select("SELECT * FROM students_courses")
   List<StudentCourse> searchCourse();
 
-  @Insert("INSERT INTO students (full_name, furigana, nickname, email_address, live_city, age, gender, remark, is_deleted) VALUES (#{fullName}, #{furigana}, #{nickname}, #{emailAddress}, #{liveCity}, #{age}, #{gender}, #{remark}, 0)")
+  @Insert("INSERT INTO students (full_name, furigana, nickname, email_address, live_city, age, gender, remark, deleted) VALUES (#{fullName}, #{furigana}, #{nickname}, #{emailAddress}, #{liveCity}, #{age}, #{gender}, #{remark}, #{deleted})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   int registerStudent(Student student);
 
@@ -43,16 +42,16 @@ public interface StudentRepository {
   @Select("SELECT * FROM students WHERE id=#{id}")
   Student getStudentInfo(int id);
 
-  @Select("SELECT course_name, start_date, scheduled_end_date FROM students_courses WHERE student_id=#{id}")
-  List<StudentCourse> getCourseInfo(int id);
+  @Select("SELECT * FROM students_courses WHERE student_id=#{studentId}")
+  List<StudentCourse> getCourseInfo(int studentId);
 
   @Update(
-      "UPDATE students SET full_name=#{fullName}, furigana=#{furigana}, email_address=#{emailAddress}, live_city=#{liveCity},age=#{age}, gender=#{gender}, remark=#{remark}"
+      "UPDATE students SET full_name=#{fullName}, furigana=#{furigana}, email_address=#{emailAddress}, live_city=#{liveCity},age=#{age}, gender=#{gender}, remark=#{remark}, deleted=#{deleted}"
           + " WHERE id=#{id}")
   int updateStudent(Student student);
 
   @Update(
       "UPDATE students_courses SET course_name=#{courseName}, start_date=#{startDate}, scheduled_end_date=#{scheduledEndDate}"
-          + " WHERE student_id=#{studentId}")
+          + " WHERE id=#{id}")
   int updateCourse(StudentCourse course);
 }

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -49,7 +49,7 @@ public class StudentService {
   public StudentDetail getStudentInfo(int id) {
     Student student = repository.getStudentInfo(id);
     List<StudentCourse> courseList = repository.getCourseInfo(id);
-    return new StudentDetail(student,courseList);
+    return new StudentDetail(student, courseList);
   }
 
   @Transactional
@@ -62,10 +62,6 @@ public class StudentService {
     }
     //todo；受講生コース情報の更新
     for (StudentCourse course : studentDetail.getStudentCourse()) {
-      course.setStudentId(student.getId());
-      course.setCourseName(course.getCourseName());
-      course.setStartDate(course.getStartDate());
-      course.setScheduledEndDate(course.getStartDate().plusMonths(6));
       int updateCourse = repository.updateCourse(course);
       if (updateCourse == 0) {
         throw new RuntimeException("students_coursesテーブルでの更新処理");

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -43,7 +43,12 @@
     <input type="text" id="remark" th:field="*{student.remark}" maxlength="100"
            style="width: 400px;"/>
   </div>
+  <div>
+    <label for="deleted">キャンセル:</label>
+    <input type="checkbox" id="deleted" th:field="*{student.deleted}"/>
+  </div>
   <div th:each="course, stat : *{studentCourse}">
+    <input type="hidden" th:field="*{studentCourse[__${stat.index}__].id}"/>
     <div>
       <label>コース名：</label>
       <select th:field="*{studentCourse[__${stat.index}__].courseName}" required>


### PR DESCRIPTION
# 課題
## データの削除(論理削除)

> ## isDeletedのキャンセルフラグをアップデートに追加→その項目をチェック→更新→一覧画面に表示させない

### **1. updateStudentにだけキャンセルのチェックボックス(更新画面にisDeleted追加)を追加して、更新（キャンセル扱いに）する。**

### **2. リストの一覧を取得するSQLのWHERE文にisDeleted=falseを追加し、一覧画面にisDeletedがtrueのものを表示させないようにする。** 



# 結果
- ## キャンセル(削除)前
![30_課題(削除前)](https://github.com/user-attachments/assets/4608e4ed-5618-4961-9dec-883928abfd66)

- ## キャンセル(削除)内容
![30_課題(削除内容)](https://github.com/user-attachments/assets/3cf70b13-1344-4f70-85a0-eada9e29d4ea)

- ## キャンセル(削除)後
![30_課題(削除後)](https://github.com/user-attachments/assets/73f23682-addd-4f05-bb6c-6422a1e9adeb)




