### PR TITLE
53_CI-CDの解説_GitHubActionsの設定：Update JavaTest.yml

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -24,5 +24,8 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
-    - name: Build with Gradle Wrapper
+    - name: Grant execute permission to gradlew
+      run: chmod +x ./gradlew
+      
+    - name: Run tests
       run: ./gradlew test


### PR DESCRIPTION
## chmod +x で実行権限の設定追加
 - name: Grant execute permission to gradlew
      run: chmod +x ./gradlew 